### PR TITLE
Add basic calendar view

### DIFF
--- a/Backend/KindNet/KindNet/Controllers/EventController.cs
+++ b/Backend/KindNet/KindNet/Controllers/EventController.cs
@@ -86,5 +86,12 @@ namespace KindNet.Controllers
             return Ok(eventDtos);
         }
 
+        [HttpGet("calendar")]
+        public async Task<IActionResult> GetPlannedAndActiveEvents()
+        {
+            var eventDtos = await _eventService.GetPlannedAndActiveEventDtosAsync();
+            return Ok(eventDtos);
+        }
+
     }
 }

--- a/Backend/KindNet/KindNet/Models/Interfaces/IEventRepository.cs
+++ b/Backend/KindNet/KindNet/Models/Interfaces/IEventRepository.cs
@@ -7,5 +7,6 @@
         Task<IEnumerable<Event>> GetAllAsync();
         Task<Event> GetOverlappingEventAsync(string city, DateTime startTime, DateTime endTime);
         Task<IEnumerable<Event>> GetAllByOrganizerIdAsync(long organizerId);
+        Task<IEnumerable<Event>> GetPlannedAndActiveEventsAsync();
     }
 }

--- a/Backend/KindNet/KindNet/Repositories/EventRepository.cs
+++ b/Backend/KindNet/KindNet/Repositories/EventRepository.cs
@@ -53,6 +53,13 @@
                 .Include(e => e.Organizer)
                 .ToListAsync();
         }
+        public async Task<IEnumerable<Event>> GetPlannedAndActiveEventsAsync()
+        {
+            return await _context.Events
+                .Where(e => e.Status == EventStatus.Planned || e.Status == EventStatus.Active)
+                .Include(e => e.Organizer)
+                .ToListAsync();
+        }
 
     }
 }

--- a/Backend/KindNet/KindNet/Services/EventService.cs
+++ b/Backend/KindNet/KindNet/Services/EventService.cs
@@ -132,5 +132,24 @@ namespace KindNet.Services
 
             return eventDtos;
         }
+
+        public async Task<IEnumerable<EventDto>> GetPlannedAndActiveEventDtosAsync()
+        {
+            var events = await _eventRepository.GetPlannedAndActiveEventsAsync();
+            var eventDtos = events.Select(e => new EventDto
+            {
+                Id = e.Id,
+                Name = e.Name,
+                Description = e.Description,
+                City = e.City,
+                StartTime = e.StartTime,
+                EndTime = e.EndTime,
+                Type = e.Type,
+                Status = e.Status,
+                ApplicationDeadline = e.ApplicationDeadline,
+                RequiredSkills = e.RequiredSkills
+            }).ToList();
+            return eventDtos;
+        }
     }
 }

--- a/Frontend/KindNet/angular.json
+++ b/Frontend/KindNet/angular.json
@@ -26,7 +26,8 @@
             ],
             "styles": [
               "src/custom-theme.scss",
-              "src/styles.css"
+              "src/styles.css",
+              "node_modules/angular-calendar/css/angular-calendar.css"
             ],
             "scripts": []
           },

--- a/Frontend/KindNet/package-lock.json
+++ b/Frontend/KindNet/package-lock.json
@@ -18,6 +18,8 @@
         "@angular/platform-browser": "^16.2.0",
         "@angular/platform-browser-dynamic": "^16.2.0",
         "@angular/router": "^16.2.0",
+        "angular-calendar": "^0.31.1",
+        "date-fns": "^4.1.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.13.0"
@@ -3889,6 +3891,12 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@mattlewis92/dom-autoscroller": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@mattlewis92/dom-autoscroller/-/dom-autoscroller-2.4.2.tgz",
+      "integrity": "sha512-YbrUWREPGEjE/FU6foXcAT1YbVwqD/jkYnY1dFb0o4AxtP3s4xKBthlELjndZih8uwsDWgQZx1eNskRNe2BgZQ==",
+      "license": "MIT"
+    },
     "node_modules/@ngtools/webpack": {
       "version": "16.2.16",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.16.tgz",
@@ -4113,6 +4121,13 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@schematics/angular": {
       "version": "16.2.16",
@@ -4924,6 +4939,51 @@
         "ajv": "^8.8.2"
       }
     },
+    "node_modules/angular-calendar": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/angular-calendar/-/angular-calendar-0.31.1.tgz",
+      "integrity": "sha512-pjSIpoAaUzS/gx+14eOr4hPZhlQ8HxpiZypCSGqJNptq5PD+vOdVQ3h/Aaqnk86GraVcAQPXqfu64MtdKwTVNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@scarf/scarf": "^1.1.1",
+        "angular-draggable-droppable": "^8.0.0",
+        "angular-resizable-element": "^7.0.0",
+        "calendar-utils": "^0.10.4",
+        "positioning": "^2.0.1",
+        "tslib": "^2.4.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mattlewis92"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=15.0.0"
+      }
+    },
+    "node_modules/angular-draggable-droppable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/angular-draggable-droppable/-/angular-draggable-droppable-8.0.0.tgz",
+      "integrity": "sha512-+gpSNBbygjV1pxTxsM3UPJKcXHXJabYoTtKcgQe74rGnb1umKc07XCBD1qDzvlG/kocthvhQ12qfYOYzHnE3ZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mattlewis92/dom-autoscroller": "^2.4.2",
+        "tslib": "^2.4.1"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=15.0.0"
+      }
+    },
+    "node_modules/angular-resizable-element": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/angular-resizable-element/-/angular-resizable-element-7.0.2.tgz",
+      "integrity": "sha512-/BGuNiA38n9klexHO1xgnsA3VYigj9v+jUGjKtBRgfB26bCxZKsNWParSu2k3EqbATrfAJC4Nl8f7cORpJFf4w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=15.0.0"
+      }
+    },
     "node_modules/ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -5495,6 +5555,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/calendar-utils": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/calendar-utils/-/calendar-utils-0.10.4.tgz",
+      "integrity": "sha512-gBK4xCJ42yjaUKwuUha6cZOfxAmGzvSgbdAaX3xLRioeKbYoOK1x1qeD6dch72rsMZlTgATPbBBx42bnkStqgQ==",
+      "license": "MIT"
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -6180,6 +6246,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/date-format": {
@@ -10634,6 +10710,12 @@
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
+    },
+    "node_modules/positioning": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/positioning/-/positioning-2.0.1.tgz",
+      "integrity": "sha512-DsAgM42kV/ObuwlRpAzDTjH9E8fGKkMDJHWFX+kfNXSxh7UCCQxEmdjv/Ws5Ft1XDnt3JT8fIDYeKNSE2TbttA==",
+      "license": "MIT"
     },
     "node_modules/postcss": {
       "version": "8.4.31",
@@ -16461,6 +16543,11 @@
         "tslib": "^2.1.0"
       }
     },
+    "@mattlewis92/dom-autoscroller": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@mattlewis92/dom-autoscroller/-/dom-autoscroller-2.4.2.tgz",
+      "integrity": "sha512-YbrUWREPGEjE/FU6foXcAT1YbVwqD/jkYnY1dFb0o4AxtP3s4xKBthlELjndZih8uwsDWgQZx1eNskRNe2BgZQ=="
+    },
     "@ngtools/webpack": {
       "version": "16.2.16",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.16.tgz",
@@ -16620,6 +16707,11 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
       "optional": true
+    },
+    "@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ=="
     },
     "@schematics/angular": {
       "version": "16.2.16",
@@ -17323,6 +17415,36 @@
         "fast-deep-equal": "^3.1.3"
       }
     },
+    "angular-calendar": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/angular-calendar/-/angular-calendar-0.31.1.tgz",
+      "integrity": "sha512-pjSIpoAaUzS/gx+14eOr4hPZhlQ8HxpiZypCSGqJNptq5PD+vOdVQ3h/Aaqnk86GraVcAQPXqfu64MtdKwTVNw==",
+      "requires": {
+        "@scarf/scarf": "^1.1.1",
+        "angular-draggable-droppable": "^8.0.0",
+        "angular-resizable-element": "^7.0.0",
+        "calendar-utils": "^0.10.4",
+        "positioning": "^2.0.1",
+        "tslib": "^2.4.1"
+      }
+    },
+    "angular-draggable-droppable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/angular-draggable-droppable/-/angular-draggable-droppable-8.0.0.tgz",
+      "integrity": "sha512-+gpSNBbygjV1pxTxsM3UPJKcXHXJabYoTtKcgQe74rGnb1umKc07XCBD1qDzvlG/kocthvhQ12qfYOYzHnE3ZA==",
+      "requires": {
+        "@mattlewis92/dom-autoscroller": "^2.4.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "angular-resizable-element": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/angular-resizable-element/-/angular-resizable-element-7.0.2.tgz",
+      "integrity": "sha512-/BGuNiA38n9klexHO1xgnsA3VYigj9v+jUGjKtBRgfB26bCxZKsNWParSu2k3EqbATrfAJC4Nl8f7cORpJFf4w==",
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
     "ansi-colors": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
@@ -17735,6 +17857,11 @@
           "dev": true
         }
       }
+    },
+    "calendar-utils": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/calendar-utils/-/calendar-utils-0.10.4.tgz",
+      "integrity": "sha512-gBK4xCJ42yjaUKwuUha6cZOfxAmGzvSgbdAaX3xLRioeKbYoOK1x1qeD6dch72rsMZlTgATPbBBx42bnkStqgQ=="
     },
     "call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -18247,6 +18374,11 @@
         "whatwg-mimetype": "^2.3.0",
         "whatwg-url": "^8.0.0"
       }
+    },
+    "date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
     "date-format": {
       "version": "4.0.14",
@@ -21588,6 +21720,11 @@
           "dev": true
         }
       }
+    },
+    "positioning": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/positioning/-/positioning-2.0.1.tgz",
+      "integrity": "sha512-DsAgM42kV/ObuwlRpAzDTjH9E8fGKkMDJHWFX+kfNXSxh7UCCQxEmdjv/Ws5Ft1XDnt3JT8fIDYeKNSE2TbttA=="
     },
     "postcss": {
       "version": "8.4.31",

--- a/Frontend/KindNet/package.json
+++ b/Frontend/KindNet/package.json
@@ -20,6 +20,8 @@
     "@angular/platform-browser": "^16.2.0",
     "@angular/platform-browser-dynamic": "^16.2.0",
     "@angular/router": "^16.2.0",
+    "angular-calendar": "^0.31.1",
+    "date-fns": "^4.1.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.13.0"

--- a/Frontend/KindNet/src/app/app-routing.module.ts
+++ b/Frontend/KindNet/src/app/app-routing.module.ts
@@ -3,6 +3,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { LayoutComponent } from './layout/layout/layout.component';
 import { EventsListComponent } from './events-list/events-list.component';
 import { CreateEventComponent } from './create-event/create-event.component';
+import { CalendarComponent } from './calendar/calendar.component';
 
 const routes: Routes = [
   {
@@ -10,7 +11,8 @@ const routes: Routes = [
     component: LayoutComponent,
     children: [
       { path: 'events', component: EventsListComponent },
-      { path: 'create-event', component: CreateEventComponent }
+      { path: 'create-event', component: CreateEventComponent },
+      { path: 'calendar', component: CalendarComponent }
     ]
   }
 ];

--- a/Frontend/KindNet/src/app/app.module.ts
+++ b/Frontend/KindNet/src/app/app.module.ts
@@ -13,19 +13,26 @@ import { MatNativeDateModule } from '@angular/material/core';
 import { HttpClientModule } from '@angular/common/http';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatCardModule } from '@angular/material/card';
-
-
+import { CalendarModule, DateAdapter } from 'angular-calendar';
+import { adapterFactory } from 'angular-calendar/date-adapters/date-fns';
+import { MatButtonModule } from '@angular/material/button';
+import { registerLocaleData } from '@angular/common'; 
+import localeSr from '@angular/common/locales/sr-Latn';
+registerLocaleData(localeSr);
 
 import { AppComponent } from './app.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { EventsListComponent } from './events-list/events-list.component';
 import { CreateEventComponent } from './create-event/create-event.component';
+import { CalendarComponent } from './calendar/calendar.component';
+
 
 @NgModule({
   declarations: [
     AppComponent,
     EventsListComponent,
-    CreateEventComponent
+    CreateEventComponent,
+    CalendarComponent
   ],
   imports: [
     BrowserModule,
@@ -42,7 +49,12 @@ import { CreateEventComponent } from './create-event/create-event.component';
     MatNativeDateModule,
     HttpClientModule,
     MatProgressSpinnerModule,
-    MatCardModule
+    MatCardModule,
+    MatButtonModule,
+    CalendarModule.forRoot({
+      provide: DateAdapter,
+      useFactory: adapterFactory,
+    })
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/Frontend/KindNet/src/app/calendar/calendar.component.css
+++ b/Frontend/KindNet/src/app/calendar/calendar.component.css
@@ -1,0 +1,50 @@
+.calendar-container {
+  padding: 20px;
+}
+
+.header-container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+}
+
+.view-buttons {
+  display: flex;
+  gap: 8px; /* Dodaje razmak između dugmadi */
+}
+
+.view-buttons button {
+  min-width: 100px;
+  background-color: #f0f0f0; /* Svetlo siva pozadina */
+  color: #333; /* Tamniji tekst */
+}
+
+.view-buttons button:hover {
+  background-color: #e0e0e0; /* Tamnija siva na hover */
+}
+
+.current-month-title h3 {
+  margin: 0;
+  color: #555;
+}
+
+.calendar-view-container {
+  background-color: #fff;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+/* Stilovi za prilagođavanje ćelije kalendara */
+.event-titles-container {
+  font-size: 12px;
+  white-space: normal;
+}
+
+.event-title {
+  padding: 2px 4px;
+  margin-top: 2px;
+  border-radius: 3px;
+  color: white;
+  white-space: normal;
+}

--- a/Frontend/KindNet/src/app/calendar/calendar.component.html
+++ b/Frontend/KindNet/src/app/calendar/calendar.component.html
@@ -1,0 +1,48 @@
+<div class="calendar-container">
+  <div class="header-container">
+    <div class="view-buttons">
+      <button mat-flat-button mwlCalendarPreviousView
+              [view]="view" [(viewDate)]="viewDate">
+        <mat-icon>chevron_left</mat-icon> Prethodni
+      </button>
+      <button mat-flat-button mwlCalendarToday
+              [(viewDate)]="viewDate">
+        <mat-icon>refresh</mat-icon> Danas
+      </button>
+      <button mat-flat-button mwlCalendarNextView
+              [view]="view" [(viewDate)]="viewDate">
+        Sledeći <mat-icon>chevron_right</mat-icon>
+      </button>
+    </div>
+
+    <div class="current-month-title">
+      <!-- Korišćenje ispravnog calendarDate pipe-a -->
+      <h3>{{ viewDate | calendarDate:(view + 'ViewTitle'):'sr-Latn' }}</h3>
+    </div>
+  </div>
+
+  <div class="calendar-view-container">
+    <mwl-calendar-month-view
+      [viewDate]="viewDate"
+      [events]="events"
+      (dayClicked)="dayClicked($event)"
+      [activeDayIsOpen]="activeDayIsOpen"
+      [cellTemplate]="cellTemplate"
+      [locale]="'sr-Latn'">
+    </mwl-calendar-month-view>
+    
+    <ng-template #cellTemplate let-day="day">
+      <div class="cal-cell-top">
+        <span class="cal-day-number">{{ day.date | date:'d' }}</span>
+      </div>
+      <div class="event-titles-container">
+        <div *ngFor="let event of day.events"
+             class="event-title"
+             [style.backgroundColor]="event.color.primary"
+             [style.color]="'white'">
+          {{ event.title }}
+        </div>
+      </div>
+    </ng-template>
+  </div>
+</div>

--- a/Frontend/KindNet/src/app/calendar/calendar.component.spec.ts
+++ b/Frontend/KindNet/src/app/calendar/calendar.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CalendarComponent } from './calendar.component';
+
+describe('CalendarComponent', () => {
+  let component: CalendarComponent;
+  let fixture: ComponentFixture<CalendarComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [CalendarComponent]
+    });
+    fixture = TestBed.createComponent(CalendarComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Frontend/KindNet/src/app/calendar/calendar.component.ts
+++ b/Frontend/KindNet/src/app/calendar/calendar.component.ts
@@ -1,0 +1,72 @@
+import { ChangeDetectorRef, Component, OnInit, ViewChild, TemplateRef, LOCALE_ID } from '@angular/core';
+import { CalendarEvent, CalendarView } from 'angular-calendar';
+import { EventService } from '../services/event.service';
+import { EventDto } from '../models/event.model';
+import { isSameDay, isSameMonth } from 'date-fns';
+import { MonthViewDay } from 'calendar-utils';
+
+@Component({
+  selector: 'app-calendar',
+  templateUrl: './calendar.component.html',
+  styleUrls: ['./calendar.component.css'],
+  providers: [
+    { provide: LOCALE_ID, useValue: 'sr-Latn' }
+  ]
+})
+export class CalendarComponent implements OnInit {
+
+  @ViewChild('cellTemplate', { static: true }) cellTemplate!: TemplateRef<any>;
+
+  view: CalendarView = CalendarView.Month;
+  viewDate: Date = new Date();
+  activeDayIsOpen: boolean = false;
+  events: CalendarEvent[] = [];
+  
+  constructor(private eventService: EventService, private cdr: ChangeDetectorRef) { }
+
+  ngOnInit(): void {
+    this.fetchEventsForCalendar();
+    this.cdr.detectChanges(); 
+  }
+
+  fetchEventsForCalendar() {
+    this.eventService.getPlannedAndActiveEvents().subscribe(
+      (events: EventDto[]) => {
+        this.events = this.mapToCalendarEvents(events);
+        this.cdr.detectChanges(); 
+      },
+      (error) => {
+        console.error('Greška prilikom dohvaćanja događaja:', error);
+      }
+    );
+  }
+
+  dayClicked({ day }: { day: MonthViewDay }): void {
+    if (isSameMonth(day.date, this.viewDate)) {
+      if ((isSameDay(this.viewDate, day.date) && this.activeDayIsOpen) || day.events.length === 0) {
+        this.activeDayIsOpen = false;
+      } else {
+        this.activeDayIsOpen = true;
+        // ❌ uklonjeno menjanje viewDate da ne blokira dugmad za mesec
+      }
+      this.cdr.detectChanges();
+    }
+  }
+
+  private mapToCalendarEvents(events: EventDto[]): CalendarEvent[] {
+    return events.map(event => {
+      const colors = {
+        primary: '#1e90ff',
+        secondary: '#D1E8FF'
+      };
+      
+      return {
+        start: new Date(event.startTime),
+        end: new Date(event.endTime),
+        title: `${event.name}`,
+        color: colors,
+        allDay: false
+      };
+    });
+  }
+}

--- a/Frontend/KindNet/src/app/layout/layout/layout.component.html
+++ b/Frontend/KindNet/src/app/layout/layout/layout.component.html
@@ -9,6 +9,9 @@
       <a mat-list-item routerLink="/events">
         <mat-icon>event</mat-icon> Događaji
       </a>
+      <a mat-list-item routerLink="/calendar">
+        <mat-icon>calendar_month</mat-icon> Kalendar
+      </a>
       <a mat-list-item routerLink="/profil">
         <mat-icon>person</mat-icon> Profil
       </a>
@@ -20,7 +23,7 @@
       <button mat-icon-button (click)="sidenav.toggle()">
         <mat-icon>menu</mat-icon>
       </button>
-      <span>Moji događaji</span> 
+      <span></span> 
     </mat-toolbar>
     
     <div class="main-content">

--- a/Frontend/KindNet/src/app/services/event.service.ts
+++ b/Frontend/KindNet/src/app/services/event.service.ts
@@ -30,4 +30,8 @@ export class EventService {
   getMyEvents(): Observable<EventDto[]> {
     return this.http.get<EventDto[]>(`${this.apiUrl}/my-events`);
   }
+
+  getPlannedAndActiveEvents(): Observable<EventDto[]> {
+    return this.http.get<EventDto[]>(`${this.apiUrl}/calendar`);
+  }
 }

--- a/Frontend/KindNet/src/styles.css
+++ b/Frontend/KindNet/src/styles.css
@@ -1,4 +1,3 @@
 /* You can add global styles to this file, and also import other style files */
-
 html, body { height: 100%; }
 body { margin: 0; font-family: 'Poppins', sans-serif; }

--- a/Frontend/KindNet/tsconfig.json
+++ b/Frontend/KindNet/tsconfig.json
@@ -1,4 +1,3 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
   "compileOnSave": false,
   "compilerOptions": {
@@ -6,8 +5,6 @@
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "noImplicitOverride": true,
-    "noPropertyAccessFromIndexSignature": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
@@ -25,7 +22,6 @@
     ]
   },
   "angularCompilerOptions": {
-    "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,
     "strictInputAccessModifiers": true,
     "strictTemplates": true


### PR DESCRIPTION
This PR introduces a basic calendar view using the angular-calendar library. The calendar displays all planned and active events fetched from the EventService.

Key features:
- Month view for easy navigation.
- Display of events on their respective days.
- Ability to navigate to previous/next months and today's date.
<img width="1920" height="925" alt="Snimak ekrana (2235)" src="https://github.com/user-attachments/assets/8d678915-8e86-443a-9990-fa09e86ab453" />
