### PR TITLE
Refactor/assign events to logged in user

### DIFF
--- a/Backend/KindNet/KindNet/KindNet.csproj
+++ b/Backend/KindNet/KindNet/KindNet.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentResults" Version="4.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.20" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.13" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="7.0.11">
       <PrivateAssets>all</PrivateAssets>

--- a/Backend/KindNet/KindNet/Program.cs
+++ b/Backend/KindNet/KindNet/Program.cs
@@ -1,8 +1,13 @@
-using KindNet.Data;
+﻿using KindNet.Data;
 using KindNet.Models.Interfaces;
 using KindNet.Repositories;
 using KindNet.Services;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+using System.IdentityModel.Tokens.Jwt;
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -10,7 +15,6 @@ var connectionString = builder.Configuration.GetConnectionString("DefaultConnect
 
 builder.Services.AddDbContext<AppDbContext>(options =>
     options.UseNpgsql(connectionString));
-
 
 builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
@@ -21,7 +25,7 @@ builder.Services.AddCors(options =>
     options.AddPolicy("AllowSpecificOrigin",
         builder =>
         {
-            builder.WithOrigins("http://localhost:4200") 
+            builder.WithOrigins("http://localhost:4200")
                    .AllowAnyHeader()
                    .AllowAnyMethod();
         });
@@ -38,6 +42,30 @@ builder.Services.AddControllers()
     });
 
 
+JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
+
+builder.Services.AddAuthentication("Bearer")
+    .AddJwtBearer("Bearer", options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = builder.Configuration["JWT_ISSUER"] ?? "KindNet",
+
+            ValidateAudience = true,
+            ValidAudience = builder.Configuration["JWT_AUDIENCE"] ?? "KindNet-frontend",
+
+            ValidateLifetime = true,
+
+            IssuerSigningKey = new SymmetricSecurityKey(
+                Encoding.UTF8.GetBytes(
+                    builder.Configuration["JWT_KEY"] ?? "diplomski_rad_kindnet_app_secret_key"
+                )
+            ),
+            ValidateIssuerSigningKey = true
+        };
+    });
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
@@ -50,8 +78,10 @@ app.UseHttpsRedirection();
 
 app.UseCors("AllowSpecificOrigin");
 
+app.UseAuthentication();
 app.UseAuthorization();
 
 app.MapControllers();
 
 app.Run();
+

--- a/Backend/KindNet/KindNet/Services/EventService.cs
+++ b/Backend/KindNet/KindNet/Services/EventService.cs
@@ -20,7 +20,7 @@ namespace KindNet.Services
             return overlappingEvent != null;
         }
 
-        public async Task<CreateEventResultDto> CreateEventAsync(CreateEventDto eventDto)
+        public async Task<CreateEventResultDto> CreateEventAsync(CreateEventDto eventDto, long organizerId)
         {
             if (!eventDto.ForceCreate)
             {
@@ -32,7 +32,6 @@ namespace KindNet.Services
                 }
             }
 
-            var temporaryOrganizerId = 1L;
             var newEvent = new Event
             {
                 Name = eventDto.Name,
@@ -42,7 +41,7 @@ namespace KindNet.Services
                 EndTime = eventDto.EndTime,
                 Type = eventDto.Type,
                 Status = EventStatus.Draft,
-                OrganizerId = temporaryOrganizerId,
+                OrganizerId = organizerId,
                 ApplicationDeadline = eventDto.ApplicationDeadline,
                 RequiredSkills = eventDto.RequiredSkills
             };

--- a/Frontend/KindNet/src/app/calendar/calendar.component.css
+++ b/Frontend/KindNet/src/app/calendar/calendar.component.css
@@ -11,17 +11,18 @@
 
 .view-buttons {
   display: flex;
-  gap: 8px; /* Dodaje razmak između dugmadi */
+  gap: 8px; 
 }
 
 .view-buttons button {
   min-width: 100px;
-  background-color: #f0f0f0; /* Svetlo siva pozadina */
-  color: #333; /* Tamniji tekst */
+  background-color: #f0f0f0; 
+  color: #333; 
+  font-family: 'Poppins', sans-serif;
 }
 
 .view-buttons button:hover {
-  background-color: #e0e0e0; /* Tamnija siva na hover */
+  background-color: #e0e0e0; 
 }
 
 .current-month-title h3 {
@@ -35,7 +36,6 @@
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
-/* Stilovi za prilagođavanje ćelije kalendara */
 .event-titles-container {
   font-size: 12px;
   white-space: normal;

--- a/Frontend/KindNet/src/app/create-event/create-event.component.ts
+++ b/Frontend/KindNet/src/app/create-event/create-event.component.ts
@@ -17,8 +17,8 @@ export class CreateEventComponent implements OnInit {
     city: '',
     startTime: new Date(), 
     endTime: new Date(), 
-    applicationDeadline: new Date(), // Inicijalizovano kao obavezno polje
-    requiredSkills: [], // Inicijalizovano kao prazan niz
+    applicationDeadline: new Date(), 
+    requiredSkills: [], 
     type: '',
     forceCreate: false
   };
@@ -27,7 +27,6 @@ export class CreateEventComponent implements OnInit {
   startTimeTime: string = '';
   endTimeDate: Date | null = null;
   endTimeTime: string = '';
-  // Nova varijabla za veštine
   requiredSkillsString: string = '';
 
   private typeMapping: { [key: string]: number } = {
@@ -70,9 +69,7 @@ export class CreateEventComponent implements OnInit {
     this.event.startTime = startDateTime;
     this.event.endTime = endDateTime;
     
-    // Konverzija stringa veština u niz
     this.event.requiredSkills = this.requiredSkillsString.split(',').map(skill => skill.trim()).filter(skill => skill.length > 0);
-    // Dodatna validacija: rok za prijavu ne sme biti nakon početka događaja
     if (this.event.applicationDeadline > this.event.startTime) {
       alert('Rok za prijavu mora biti pre datuma početka događaja.');
       return;
@@ -99,7 +96,6 @@ export class CreateEventComponent implements OnInit {
       City: this.event.city,
       StartTime: this.event.startTime.toISOString(),
       EndTime: this.event.endTime.toISOString(),
-      // Dodati novi podaci
       ApplicationDeadline: this.event.applicationDeadline.toISOString(),
       RequiredSkills: this.event.requiredSkills,
       Type: this.typeMapping[this.event.type],
@@ -112,7 +108,7 @@ export class CreateEventComponent implements OnInit {
       .subscribe(result => {
         if (result && !result.isOverlapping) {
           alert('Događaj uspješno kreiran!');
-          this.router.navigate(['/events']);
+          this.router.navigate(['/layout/events']);
         }
       });
   }
@@ -126,7 +122,6 @@ export class CreateEventComponent implements OnInit {
       City: this.event.city,
       StartTime: this.event.startTime.toISOString(),
       EndTime: this.event.endTime.toISOString(),
-      // Dodati novi podaci
       ApplicationDeadline: this.event.applicationDeadline.toISOString(),
       RequiredSkills: this.event.requiredSkills,
       Type: this.typeMapping[this.event.type],
@@ -136,7 +131,7 @@ export class CreateEventComponent implements OnInit {
     this.eventService.createEvent(eventToSend)
       .subscribe(result => {
         alert('Događaj uspješno kreiran uprkos preklapanju!');
-        this.router.navigate(['/events']);
+        this.router.navigate(['/layout/events']);
       });
   }
 }


### PR DESCRIPTION
This PR refactors the event creation process to correctly assign the OrganizerId based on the currently authenticated user's ID extracted from the JWT token. This replaces the previous hardcoded OrganizerId.

Key changes include:
- Updated EventController to extract the userId claim from the JWT.
- Modified EventService.CreateEventAsync to accept the organizerId from the controller.
- Ensured GetMyEvents correctly filters events by the authenticated user's ID.