### PR TITLE
feat: add event type-based colors and modal on click

### DIFF
--- a/Frontend/KindNet/src/app/app.module.ts
+++ b/Frontend/KindNet/src/app/app.module.ts
@@ -24,6 +24,8 @@ import { MatExpansionModule } from '@angular/material/expansion';
 import { MatListModule } from '@angular/material/list';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatChipsModule } from '@angular/material/chips';
+import { MatTooltip } from '@angular/material/tooltip';
+
 import { AppComponent } from './app.component';
 import { LoginComponent } from './login/login.component';
 import { SignUpComponent } from './sign-up/sign-up.component';
@@ -69,6 +71,7 @@ export function tokenGetter() {
     MatOptionModule,
     MatDatepickerModule,
     MatNativeDateModule,
+    MatTooltipModule,
     MatProgressSpinnerModule,
     MatCardModule,
     MatButtonModule,

--- a/Frontend/KindNet/src/app/calendar/calendar.component.css
+++ b/Frontend/KindNet/src/app/calendar/calendar.component.css
@@ -31,21 +31,30 @@
   border-radius: 8px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
+
 .event-titles-container {
   font-size: 12px;
   max-height: 68px; 
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  
 }
 
 .event-title {
   padding: 2px 4px;
-  margin-top: 2px;
   border-radius: 3px;
   color: white;
   white-space: normal; 
   line-height: 1.3; 
   overflow: hidden;
   text-overflow: ellipsis;
+  cursor: pointer;
+}
+
+.event-title:first-child {
+  margin-top: -3px; 
 }
 
 .filters-container {
@@ -105,4 +114,66 @@
   font-style: italic;
   color: #6c757d;
   border-bottom: 1px solid #eee;
+}
+
+/* Stilovi za modal */
+.modal-backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.6);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000;
+  animation: fadeIn 0.3s ease-out;
+}
+
+.modal-content {
+  background-color: #ffffff;
+  padding: 30px;
+  border-radius: 12px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+  max-width: 600px;
+  width: 90%;
+  position: relative;
+  animation: slideUp 0.3s ease-out;
+  font-family: 'Poppins', sans-serif;
+}
+
+.modal-close-btn {
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  background: none;
+  border: none;
+  font-size: 24px;
+  cursor: pointer;
+  color: #888;
+}
+
+.modal-title {
+  font-size: 24px;
+  font-weight: 700;
+  color: #333;
+  margin-top: 0;
+  margin-bottom: 15px;
+}
+
+.modal-body {
+  font-size: 16px;
+  line-height: 1.6;
+  color: #555;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes slideUp {
+  from { transform: translateY(20px); opacity: 0; }
+  to { transform: translateY(0); opacity: 1; }
 }

--- a/Frontend/KindNet/src/app/calendar/calendar.component.html
+++ b/Frontend/KindNet/src/app/calendar/calendar.component.html
@@ -70,10 +70,24 @@
         <div *ngFor="let event of day.events"
              class="event-title"
              [style.backgroundColor]="event.color.primary"
-             [style.color]="'white'">
+             [style.color]="'white'"
+             (click)="openModal(event, $event)">
           {{ event.title }}
         </div>
       </div>
     </ng-template>
+  </div>
+</div>
+
+<div class="modal-backdrop" *ngIf="isModalOpen" (click)="closeModal()">
+  <div class="modal-content" (click)="$event.stopPropagation()">
+    <button class="modal-close-btn" (click)="closeModal()">
+      <mat-icon>close</mat-icon>
+    </button>
+    <h2 class="modal-title">{{ selectedEvent?.title }}</h2>
+    <div class="modal-body">
+      <p><b>Organizator:</b> {{ selectedEvent?.meta.organizer }}</p>
+      <p><b>Opis:</b> {{ selectedEvent?.meta.description }}</p>
+    </div>
   </div>
 </div>

--- a/Frontend/KindNet/src/app/utils/colors.ts
+++ b/Frontend/KindNet/src/app/utils/colors.ts
@@ -1,0 +1,34 @@
+export const colors: any[] = [
+  {
+    primary: '#4d80e6',
+    secondary: '#D1E8FF'
+  },
+  {
+    primary: '#ff6b6b', 
+    secondary: '#FFDFDF'
+  },
+  {
+    primary: '#ffa500', 
+    secondary: '#FFEDCC'
+  },
+  {
+    primary: '#1d9179',
+    secondary: '#b2dfdb'
+  },
+  {
+    primary: '#8e44ad', 
+    secondary: '#D2B4DE'
+  },
+  {
+    primary: '#3498db', 
+    secondary: '#aed6f1'
+  },
+  {
+    primary: '#2ecc71', 
+    secondary: '#D5F5E3'
+  },
+  {
+    primary: '#f39c12', 
+    secondary: '#FDEBD0'
+  }
+];


### PR DESCRIPTION
This PR introduces two main UI enhancements for the calendar component:
- Event Coloring: Events are now color-coded based on their type, improving visual organization and making it easier to identify different categories of events at a glance. A new colors.ts utility file was added for this purpose.
- Event Details on Click: Clicking on a calendar event now opens a custom modal that displays essential details, including a full description and organizer name. This provides users with more context without leaving the calendar view.
<img width="1897" height="910" alt="Snimak ekrana (2314)" src="https://github.com/user-attachments/assets/8eec6dba-7af1-4969-88e6-f3787821c268" />
<img width="1885" height="926" alt="Snimak ekrana (2315)" src="https://github.com/user-attachments/assets/8d4315d6-77d2-4d3f-a97c-060a947b9983" />


