### PR TITLE
feat: create resources requests while creating event

### DIFF
--- a/Backend/KindNet/KindNet/Controllers/ResourceController.cs
+++ b/Backend/KindNet/KindNet/Controllers/ResourceController.cs
@@ -1,0 +1,59 @@
+﻿using KindNet.Dtos;
+using KindNet.Services;
+using Microsoft.AspNetCore.Mvc;
+using System.ComponentModel.Design;
+
+namespace KindNet.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class ResourcesController : ControllerBase
+    {
+        private readonly ResourceService _resourceService;
+
+        public ResourcesController(ResourceService resourceService)
+        {
+            _resourceService = resourceService;
+        }
+
+       /* [HttpGet("{id}")]
+        public async Task<ActionResult<ResourceDto>> GetById(long id)
+        {
+            var resource = await _resourceService.GetByIdAsync(id);
+            if (resource == null) return NotFound();
+            return Ok(resource);
+        }
+
+        [HttpGet("event/{eventId}")]
+        public async Task<ActionResult<IEnumerable<ResourceDto>>> GetByEventId(long eventId)
+        {
+            var resources = await _resourceService.GetByEventIdAsync(eventId);
+            return Ok(resources);
+        }
+
+        [HttpPost]
+        public async Task<ActionResult<ResourceDto>> Create([FromBody] ResourceDto dto)
+        {
+            var created = await _resourceService.CreateAsync(dto);
+            return CreatedAtAction(nameof(GetById), new { id = created.Id }, created);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<ActionResult<ResourceDto>> Update(long id, [FromBody] ResourceDto dto)
+        {
+            if (id != dto.Id) return BadRequest("Mismatched resource id");
+
+            var updated = await _resourceService.UpdateAsync(dto);
+            return Ok(updated);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(long id)
+        {
+            var deleted = await _resourceService.DeleteAsync(id);
+            if (!deleted) return NotFound();
+
+            return NoContent();
+        }*/
+    }
+}

--- a/Backend/KindNet/KindNet/Data/AppDbContext.cs
+++ b/Backend/KindNet/KindNet/Data/AppDbContext.cs
@@ -11,5 +11,7 @@
         public DbSet<Event> Events { get; set; }
         public DbSet<EventApplication> EventApplications { get; set; }
         public DbSet<Notification> Notifications { get; set; }
+        public DbSet<ResourceRequest> ResourceRequests { get; set; }
+        public DbSet<ResourceFulfillment> ResourceFulfillments { get; set; }    
     }
 }

--- a/Backend/KindNet/KindNet/Dtos/CreateEventDto.cs
+++ b/Backend/KindNet/KindNet/Dtos/CreateEventDto.cs
@@ -25,5 +25,7 @@
         [Required]
         public DateTime ApplicationDeadline { get; set; }
         public List<string> RequiredSkills { get; set; }
+        public List<CreateResourceRequestDto> ResourceRequests { get; set; } = new();
+
     }
 }

--- a/Backend/KindNet/KindNet/Dtos/CreateResourceFulfillmentDto.cs
+++ b/Backend/KindNet/KindNet/Dtos/CreateResourceFulfillmentDto.cs
@@ -1,0 +1,9 @@
+﻿namespace KindNet.Dtos
+{
+    public class CreateResourceFulfillmentDto
+    {
+        public long RequestId { get; set; }
+        public long ProviderUserId { get; set; }
+        public int QuantityProvided { get; set; }
+    }
+}

--- a/Backend/KindNet/KindNet/Dtos/CreateResourceRequestDto.cs
+++ b/Backend/KindNet/KindNet/Dtos/CreateResourceRequestDto.cs
@@ -1,0 +1,12 @@
+﻿using KindNet.Models.Enums;
+
+namespace KindNet.Dtos
+{
+    public class CreateResourceRequestDto
+    {
+        public long EventId { get; set; }
+        public string ItemName { get; set; }
+        public ResourceCategory Category { get; set; }
+        public int QuantityNeeded { get; set; }
+    }
+}

--- a/Backend/KindNet/KindNet/Dtos/EventDto.cs
+++ b/Backend/KindNet/KindNet/Dtos/EventDto.cs
@@ -31,5 +31,6 @@ namespace KindNet.Dtos
         public List<string> RequiredSkills { get; set; }
 
         public string? OrganizerName {get; set;}
+        public List<ResourceRequestDto> ResourceRequests { get; set; } = new();
     }
 }

--- a/Backend/KindNet/KindNet/Dtos/ResourceFulfillmentDto.cs
+++ b/Backend/KindNet/KindNet/Dtos/ResourceFulfillmentDto.cs
@@ -1,0 +1,11 @@
+﻿namespace KindNet.Dtos
+{
+    public class ResourceFulfillmentDto
+    {
+        public long Id { get; set; }
+        public long RequestId { get; set; }
+        public long ProviderUserId { get; set; }
+        public int QuantityProvided { get; set; }
+        public DateTime AgreementTime { get; set; }
+    }
+}

--- a/Backend/KindNet/KindNet/Dtos/ResourceRequestDto.cs
+++ b/Backend/KindNet/KindNet/Dtos/ResourceRequestDto.cs
@@ -1,0 +1,15 @@
+﻿using KindNet.Models.Enums;
+
+namespace KindNet.Dtos
+{
+    public class ResourceRequestDto
+    {
+        public long Id { get; set; }
+        public long EventId { get; set; }
+        public string ItemName { get; set; }
+        public ResourceCategory Category { get; set; }
+        public int QuantityNeeded { get; set; }
+        public int QuantityFulfilled { get; set; }
+        public ResourceRequestStatus Status { get; set; }
+    }
+}

--- a/Backend/KindNet/KindNet/Dtos/UpdateResourceRequestDto.cs
+++ b/Backend/KindNet/KindNet/Dtos/UpdateResourceRequestDto.cs
@@ -1,0 +1,13 @@
+﻿using KindNet.Models.Enums;
+
+namespace KindNet.Dtos
+{
+    public class UpdateResourceRequestDto
+    {
+        public long Id { get; set; }
+        public long EventId { get; set; }
+        public string ItemName { get; set; } = string.Empty;
+        public ResourceCategory Category { get; set; }
+        public int QuantityNeeded { get; set; }
+    }
+}

--- a/Backend/KindNet/KindNet/Migrations/20250909194654_AddResourceEntity.Designer.cs
+++ b/Backend/KindNet/KindNet/Migrations/20250909194654_AddResourceEntity.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using KindNet.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace KindNet.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250909194654_AddResourceEntity")]
+    partial class AddResourceEntity
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Backend/KindNet/KindNet/Migrations/20250909194654_AddResourceEntity.cs
+++ b/Backend/KindNet/KindNet/Migrations/20250909194654_AddResourceEntity.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace KindNet.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddResourceEntity : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ResourceRequests",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    EventId = table.Column<long>(type: "bigint", nullable: false),
+                    ItemName = table.Column<string>(type: "text", nullable: false),
+                    Category = table.Column<int>(type: "integer", nullable: false),
+                    QuantityNeeded = table.Column<int>(type: "integer", nullable: false),
+                    QuantityFulfilled = table.Column<int>(type: "integer", nullable: false),
+                    Status = table.Column<int>(type: "integer", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ResourceRequests", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ResourceRequests_Events_EventId",
+                        column: x => x.EventId,
+                        principalTable: "Events",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "ResourceFulfillments",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    RequestId = table.Column<long>(type: "bigint", nullable: false),
+                    ProviderUserId = table.Column<long>(type: "bigint", nullable: false),
+                    ProviderId = table.Column<long>(type: "bigint", nullable: false),
+                    QuantityProvided = table.Column<int>(type: "integer", nullable: false),
+                    AgreementTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ResourceFulfillments", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ResourceFulfillments_ResourceRequests_RequestId",
+                        column: x => x.RequestId,
+                        principalTable: "ResourceRequests",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_ResourceFulfillments_Users_ProviderId",
+                        column: x => x.ProviderId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ResourceFulfillments_ProviderId",
+                table: "ResourceFulfillments",
+                column: "ProviderId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ResourceFulfillments_RequestId",
+                table: "ResourceFulfillments",
+                column: "RequestId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ResourceRequests_EventId",
+                table: "ResourceRequests",
+                column: "EventId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ResourceFulfillments");
+
+            migrationBuilder.DropTable(
+                name: "ResourceRequests");
+        }
+    }
+}

--- a/Backend/KindNet/KindNet/Models/Enums/ResourceCategory.cs
+++ b/Backend/KindNet/KindNet/Models/Enums/ResourceCategory.cs
@@ -1,0 +1,14 @@
+﻿namespace KindNet.Models.Enums
+{
+    public enum ResourceCategory
+    {
+        Oprema,
+        Prostor,
+        Prevoz,
+        Materijal,
+        Hrana,
+        Piće,
+        Ostalo
+    }
+
+}

--- a/Backend/KindNet/KindNet/Models/Enums/ResourceRequestStatus.cs
+++ b/Backend/KindNet/KindNet/Models/Enums/ResourceRequestStatus.cs
@@ -1,0 +1,9 @@
+﻿namespace KindNet.Models.Enums
+{
+    public enum ResourceRequestStatus
+    {
+        Open,
+        Pending,
+        Fulfilled
+    }
+}

--- a/Backend/KindNet/KindNet/Models/Event.cs
+++ b/Backend/KindNet/KindNet/Models/Event.cs
@@ -23,5 +23,6 @@
         public EventStatus Status { get; set; }
         public DateTime ApplicationDeadline { get; set; }
         public List<string> RequiredSkills { get; set; }
+        public List<ResourceRequest> ResourcesRequests { get; set; } = new List<ResourceRequest>();
     }
 }

--- a/Backend/KindNet/KindNet/Models/Interfaces/IResourceRepository.cs
+++ b/Backend/KindNet/KindNet/Models/Interfaces/IResourceRepository.cs
@@ -1,0 +1,14 @@
+﻿namespace KindNet.Models.Interfaces
+{
+    public interface IResourceRepository
+    {
+        Task<ResourceRequest> GetRequestByIdAsync(long id);
+        Task<IEnumerable<ResourceRequest>> GetByEventIdAsync(long eventId);
+        Task<ResourceRequest> AddAsync(ResourceRequest request);
+        Task<ResourceRequest> UpdateAsync(ResourceRequest request);
+        Task<bool> DeleteAsync(long id);
+        Task<ResourceFulfillment> GetFulfillmentByIdAsync(long id);
+        Task<IEnumerable<ResourceFulfillment>> GetByRequestIdAsync(long requestId);
+        Task<ResourceFulfillment> AddAsync(ResourceFulfillment fulfillment);
+    }
+}

--- a/Backend/KindNet/KindNet/Models/ResourceFulfillment.cs
+++ b/Backend/KindNet/KindNet/Models/ResourceFulfillment.cs
@@ -1,0 +1,24 @@
+﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations;
+
+namespace KindNet.Models
+{
+    public class ResourceFulfillment
+    {
+        [Key]
+        public long Id { get; set; }
+
+        [ForeignKey("ResourceRequest")]
+        public long RequestId { get; set; }
+        public ResourceRequest Request { get; set; }
+
+        [ForeignKey("User")]
+        public long ProviderUserId { get; set; }
+        public User Provider { get; set; }
+
+        [Required]
+        public int QuantityProvided { get; set; }
+
+        public DateTime AgreementTime { get; set; } = DateTime.UtcNow;
+    }
+}

--- a/Backend/KindNet/KindNet/Models/ResourceRequest.cs
+++ b/Backend/KindNet/KindNet/Models/ResourceRequest.cs
@@ -1,0 +1,31 @@
+﻿using KindNet.Models.Enums;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations;
+
+namespace KindNet.Models
+{
+    public class ResourceRequest
+    {
+        [Key]
+        public long Id { get; set; }
+
+        [ForeignKey("Event")]
+        public long EventId { get; set; }
+        public Event Event { get; set; }
+
+        [Required]
+        public string ItemName { get; set; }
+
+        [Required]
+        public ResourceCategory Category { get; set; }
+
+        [Required]
+        public int QuantityNeeded { get; set; }
+
+        public int QuantityFulfilled { get; set; } = 0;
+
+        public ResourceRequestStatus Status { get; set; } = ResourceRequestStatus.Open;
+
+        public List<ResourceFulfillment> Fulfillments { get; set; } = new();
+    }
+}

--- a/Backend/KindNet/KindNet/Program.cs
+++ b/Backend/KindNet/KindNet/Program.cs
@@ -70,6 +70,8 @@ builder.Services.AddScoped<IApplicationRepository, ApplicationRepository>();
 builder.Services.AddScoped<ApplicationService>();
 builder.Services.AddScoped<INotificationRepository, NotificationRepository>();
 builder.Services.AddScoped<INotificationService, NotificationService>();
+builder.Services.AddScoped<IResourceRepository, ResourceRepository>();
+builder.Services.AddScoped<ResourceService>();
 builder.Services.AddControllers()
     .AddJsonOptions(options =>
     {

--- a/Backend/KindNet/KindNet/Repositories/ResourceRepository.cs
+++ b/Backend/KindNet/KindNet/Repositories/ResourceRepository.cs
@@ -1,0 +1,113 @@
+﻿using KindNet.Models.Interfaces;
+using KindNet.Models;
+using KindNet.Data;
+using Microsoft.EntityFrameworkCore;
+using KindNet.Models.Enums;
+
+namespace KindNet.Repositories
+{
+    public class ResourceRepository : IResourceRepository
+    {
+        private readonly AppDbContext _context;
+
+        public ResourceRepository(AppDbContext context)
+        {
+            _context = context;
+        }
+
+        //Dodavanje requesta
+        public async Task<ResourceRequest> AddAsync(ResourceRequest request)
+        {
+            _context.ResourceRequests.Add(request);
+            await _context.SaveChangesAsync();
+            return request;
+        }
+
+        //Dodavanje fulfillmenta i update fulfilled količine u requestu
+        public async Task<ResourceFulfillment> AddAsync(ResourceFulfillment fulfillment)
+        {
+            var request = await _context.ResourceRequests
+                .FirstOrDefaultAsync(r => r.Id == fulfillment.RequestId);
+
+            if (request == null)
+                throw new InvalidOperationException($"Request with id {fulfillment.RequestId} not found.");
+
+            _context.ResourceFulfillments.Add(fulfillment);
+
+            request.QuantityFulfilled += fulfillment.QuantityProvided;
+
+            if (request.QuantityFulfilled >= request.QuantityNeeded)
+                request.Status = ResourceRequestStatus.Fulfilled;
+            else
+                request.Status = ResourceRequestStatus.Pending;
+
+            await _context.SaveChangesAsync();
+            return fulfillment;
+        }
+
+        //Brisanje requesta i njegovih fulfillmenta
+        public async Task<bool> DeleteAsync(long id)
+        {
+            var request = await _context.ResourceRequests
+                .Include(r => r.Fulfillments)
+                .FirstOrDefaultAsync(r => r.Id == id);
+
+            if (request == null)
+                return false;
+
+            _context.ResourceFulfillments.RemoveRange(request.Fulfillments);
+            _context.ResourceRequests.Remove(request);
+
+            await _context.SaveChangesAsync();
+            return true;
+        }
+
+        //Svi requestovi za određeni event
+        public async Task<IEnumerable<ResourceRequest>> GetByEventIdAsync(long eventId)
+        {
+            return await _context.ResourceRequests
+                .Include(r => r.Fulfillments)
+                .Where(r => r.EventId == eventId)
+                .ToListAsync();
+        }
+
+        //Svi fulfillmenti za određeni request
+        public async Task<IEnumerable<ResourceFulfillment>> GetByRequestIdAsync(long requestId)
+        {
+            return await _context.ResourceFulfillments
+                .Where(f => f.RequestId == requestId)
+                .ToListAsync();
+        }
+
+        //Fulfillment po id
+        public async Task<ResourceFulfillment> GetFulfillmentByIdAsync(long id)
+        {
+            return await _context.ResourceFulfillments
+                .FirstOrDefaultAsync(f => f.Id == id);
+        }
+
+        //Request po id
+        public async Task<ResourceRequest> GetRequestByIdAsync(long id)
+        {
+            return await _context.ResourceRequests
+                .Include(r => r.Fulfillments)
+                .FirstOrDefaultAsync(r => r.Id == id);
+        }
+
+        //Update requesta (npr. ako se menja naziv ili kategorija)
+        public async Task<ResourceRequest> UpdateAsync(ResourceRequest request)
+        {
+            var existing = await _context.ResourceRequests.FindAsync(request.Id);
+            if (existing == null)
+                throw new InvalidOperationException($"Request with id {request.Id} not found.");
+
+            existing.ItemName = request.ItemName;
+            existing.Category = request.Category;
+            existing.QuantityNeeded = request.QuantityNeeded;
+            existing.Status = request.Status;
+
+            await _context.SaveChangesAsync();
+            return existing;
+        }
+    }
+}

--- a/Backend/KindNet/KindNet/Services/ResourceService.cs
+++ b/Backend/KindNet/KindNet/Services/ResourceService.cs
@@ -1,0 +1,141 @@
+﻿using KindNet.Models.Interfaces;
+using KindNet.Models;
+using KindNet.Dtos;
+using KindNet.Models.Enums;
+
+namespace KindNet.Services
+{
+    public class ResourceService 
+    {
+        private readonly IResourceRepository _resourceRepository;
+
+        public ResourceService(IResourceRepository resourceRepository)
+        {
+            _resourceRepository = resourceRepository;
+        }
+
+        public async Task<ResourceRequestDto> CreateRequestAsync(CreateResourceRequestDto dto)
+        {
+            var request = new ResourceRequest
+            {
+                EventId = dto.EventId,
+                ItemName = dto.ItemName,
+                Category = dto.Category,
+                QuantityNeeded = dto.QuantityNeeded,
+                QuantityFulfilled = 0,
+                Status = ResourceRequestStatus.Open
+            };
+
+            var saved = await _resourceRepository.AddAsync(request);
+            return MapToDto(saved);
+        }
+
+        // ➤ Kreiranje fulfillmenta
+        public async Task<ResourceFulfillmentDto> CreateFulfillmentAsync(CreateResourceFulfillmentDto dto)
+        {
+            var fulfillment = new ResourceFulfillment
+            {
+                RequestId = dto.RequestId,
+                ProviderUserId = dto.ProviderUserId,
+                QuantityProvided = dto.QuantityProvided,
+                AgreementTime = DateTime.UtcNow
+            };
+
+            var saved = await _resourceRepository.AddAsync(fulfillment);
+            return MapToDto(saved);
+        }
+
+        public async Task<IEnumerable<ResourceRequestDto>> GetRequestsByEventAsync(long eventId)
+        {
+            var requests = await _resourceRepository.GetByEventIdAsync(eventId);
+            return requests.Select(MapToDto);
+        }
+
+        public async Task<IEnumerable<ResourceFulfillmentDto>> GetFulfillmentsByRequestAsync(long requestId)
+        {
+            var fulfillments = await _resourceRepository.GetByRequestIdAsync(requestId);
+            return fulfillments.Select(MapToDto);
+        }
+
+        public async Task<ResourceRequestDto?> GetRequestByIdAsync(long id)
+        {
+            var request = await _resourceRepository.GetRequestByIdAsync(id);
+            return request == null ? null : MapToDto(request);
+        }
+
+        public async Task<ResourceFulfillmentDto?> GetFulfillmentByIdAsync(long id)
+        {
+            var fulfillment = await _resourceRepository.GetFulfillmentByIdAsync(id);
+            return fulfillment == null ? null : MapToDto(fulfillment);
+        }
+
+        public async Task<ResourceRequestDto?> UpdateRequestAsync(UpdateResourceRequestDto dto)
+        {
+            var request = new ResourceRequest
+            {
+                Id = dto.Id,
+                EventId = dto.EventId,
+                ItemName = dto.ItemName,
+                Category = dto.Category,
+                QuantityNeeded = dto.QuantityNeeded
+            };
+
+            var updated = await _resourceRepository.UpdateAsync(request);
+            return MapToDto(updated);
+        }
+
+        public async Task<bool> DeleteRequestAsync(long id)
+        {
+            return await _resourceRepository.DeleteAsync(id);
+        }
+
+        public async Task SyncEventResourcesAsync(long eventId, IEnumerable<ResourceRequest> newResources)
+        {
+            var existingResources = await _resourceRepository.GetByEventIdAsync(eventId);
+
+            foreach (var resource in existingResources)
+            {
+                await _resourceRepository.DeleteAsync(resource.Id); 
+            }
+
+            foreach (var newResource in newResources)
+            {
+                newResource.EventId = eventId;
+                var request = new ResourceRequest
+                {
+                    EventId = newResource.EventId,
+                    ItemName = newResource.ItemName,
+                    Category = newResource.Category,
+                    QuantityNeeded = newResource.QuantityNeeded,
+                    QuantityFulfilled = 0,
+                    Status = ResourceRequestStatus.Open
+                };
+                await _resourceRepository.AddAsync(newResource); 
+            }
+        }
+
+
+        private static ResourceRequestDto MapToDto(ResourceRequest request) =>
+            new()
+            {
+                Id = request.Id,
+                EventId = request.EventId,
+                ItemName = request.ItemName,
+                Category = request.Category,
+                QuantityNeeded = request.QuantityNeeded,
+                QuantityFulfilled = request.QuantityFulfilled,
+                Status = request.Status
+            };
+
+        private static ResourceFulfillmentDto MapToDto(ResourceFulfillment fulfillment) =>
+            new()
+            {
+                Id = fulfillment.Id,
+                RequestId = fulfillment.RequestId,
+                ProviderUserId = fulfillment.ProviderUserId,
+                QuantityProvided = fulfillment.QuantityProvided,
+                AgreementTime = fulfillment.AgreementTime
+            };
+    
+    }
+}

--- a/Frontend/KindNet/src/app/app.module.ts
+++ b/Frontend/KindNet/src/app/app.module.ts
@@ -5,7 +5,7 @@ import { LayoutModule } from './layout/layout.module';
 import { MatIconModule } from '@angular/material/icon'; 
 import { MatFormFieldModule } from '@angular/material/form-field'; 
 import { MatInputModule } from '@angular/material/input'; 
-import { FormsModule } from '@angular/forms'; 
+import { FormsModule, ReactiveFormsModule } from '@angular/forms'; 
 import { MatSelectModule } from '@angular/material/select'; 
 import { MatOptionModule } from '@angular/material/core';
 import { MatDatepickerModule } from '@angular/material/datepicker';
@@ -26,6 +26,7 @@ import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatChipsModule } from '@angular/material/chips';
 import { MarkdownModule } from 'ngx-markdown'; 
 import { MatDialogModule } from '@angular/material/dialog';
+import { MatTableModule } from '@angular/material/table';
 import { ToastrModule } from 'ngx-toastr';
 import { AppComponent } from './app.component';
 import { LoginComponent } from './login/login.component';
@@ -41,6 +42,7 @@ import { EventsListComponent } from './events-list/events-list.component';
 import { CreateEventComponent } from './create-event/create-event.component';
 import { CalendarComponent } from './calendar/calendar.component';
 import { ApplicationsDashboardComponent } from './applications-dashboard/applications-dashboard.component';
+import { CreateResourceDialogComponent } from './create-resource-dialog/create-resource-dialog.component';
 
 export function tokenGetter() {
   return localStorage.getItem('jwt');
@@ -55,7 +57,8 @@ export function tokenGetter() {
     EventsListComponent,
     CreateEventComponent,
     CalendarComponent,
-    ApplicationsDashboardComponent
+    ApplicationsDashboardComponent,
+    CreateResourceDialogComponent
   ],
 
   imports: [
@@ -89,6 +92,8 @@ export function tokenGetter() {
     MatChipsModule,
     MatTooltipModule,
     BrowserAnimationsModule, 
+    ReactiveFormsModule,
+    MatTableModule,
      ToastrModule.forRoot({
       positionClass: 'toast-bottom-right' 
     }),

--- a/Frontend/KindNet/src/app/create-event/create-event.component.css
+++ b/Frontend/KindNet/src/app/create-event/create-event.component.css
@@ -43,8 +43,7 @@ h2 {
 }
 
 .save-button {
-  background-color: #e07a5f;
-  color: #fff;
+  background-color: #fff;
   border-radius: 8px;
   padding: 8px 16px;
   font-weight: 500;
@@ -297,4 +296,126 @@ h2 {
 .markdown-result-col h3 {
   font-size: 16px;
   color: #9e9e9e;
+}
+
+.resource-cards-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem; 
+  margin-top: 1rem;
+  max-height: 250px; 
+  overflow-y: auto;
+}
+
+.resource-card {
+  width: 200px; 
+  background-color: #f5f5f5;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0,0,0,0.1); 
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  position: relative; 
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.resource-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 6px 16px rgba(0,0,0,0.15);
+}
+
+.resource-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
+.resource-name {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #333;
+  margin: 0;
+  line-height: 1.2;
+}
+
+
+.resource-details {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.detail-item p {
+  margin: 0;
+  font-size: 0.9rem;
+  color: #666;
+  font-weight: 500;
+}
+
+.quantity-badge {
+  background-color: #9adb9c; 
+  color: white;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%; 
+  font-size: 1.5rem;
+  font-weight: bold;
+  margin-bottom: 0.5rem;
+}
+
+mat-card-actions {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.5rem 0;
+}
+
+.category-badge-equipment {
+  color: #ffc107; 
+}
+
+.category-badge-food {
+  color: #28a745;}
+
+.category-badge-drink {
+  color: #007bff; 
+}
+
+.category-badge-space {
+  color: #6c757d;
+}
+
+.category-badge-transport {
+  color: #dc3545;
+}
+
+.category-badge-material {
+  color: #17a2b8; 
+}
+
+.category-badge-other {
+  color: #fd7e14; 
+}
+
+.category-badge {
+  padding: 0.25rem 0.5rem; 
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  align-self: flex-end;
 }

--- a/Frontend/KindNet/src/app/create-event/create-event.component.html
+++ b/Frontend/KindNet/src/app/create-event/create-event.component.html
@@ -112,6 +112,7 @@
         <div class="skills-checkbox-group">
           <mat-checkbox *ngFor="let skill of suggestedSkills"
                         [value]="skill"
+                        [checked]="selectedSkills.includes(skill)"
                         (change)="onSkillSelect(skill, $event)">
             {{ skill }}
           </mat-checkbox>
@@ -121,6 +122,37 @@
           <input matInput placeholder="Npr. programiranje, komunikacija, dizajn" [(ngModel)]="otherSkills" name="otherSkills">
         </mat-form-field>
       </div>
+
+    <div class="resources-section">
+  <button mat-stroked-button color="primary" type="button" (click)="addResource()">
+    <mat-icon>add</mat-icon> Dodaj zahtjev za resurs
+  </button>
+
+  <div class="resource-cards-container" *ngIf="event.resourceRequests.length > 0">
+  <mat-card *ngFor="let resource of event.resourceRequests; let i = index" class="resource-card">
+    <mat-card-content>
+      <div class="resource-header">
+        <h3 class="resource-name">{{ resource.itemName }}</h3>
+         <div class="category-badge" [ngClass]="getCategoryClass(resource.category)" [matTooltip]="getResourceCategoryName(resource.category)">
+    <mat-icon>{{ getCategoryIcon(resource.category) }}</mat-icon>
+  </div>
+      </div>
+      <div class="resource-details">
+        <div class="detail-item">
+          <span class="quantity-badge">{{ resource.quantityNeeded }}</span>
+          <p>Potrebna količina</p>
+        </div>
+      </div>
+    </mat-card-content>
+    <mat-card-actions>
+      <button mat-icon-button color="warn" (click)="removeResource(i)" matTooltip="Ukloni resurs">
+        <mat-icon>delete_outline</mat-icon>
+      </button>
+    </mat-card-actions>
+  </mat-card>
+</div>
+</div>
+
 
       <div class="button-container">
         <button mat-flat-button 

--- a/Frontend/KindNet/src/app/create-event/create-event.component.ts
+++ b/Frontend/KindNet/src/app/create-event/create-event.component.ts
@@ -5,6 +5,8 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { NgForm } from '@angular/forms'; 
 import { MatDialog } from '@angular/material/dialog';
 import { ToastService } from '../services/toast.service'; 
+import { ResourceCategory, ResourceRequest } from '../models/resource.model';
+import { CreateResourceDialogComponent } from '../create-resource-dialog/create-resource-dialog.component';
 
 @Component({
   selector: 'app-create-event',
@@ -28,7 +30,8 @@ export class CreateEventComponent implements OnInit {
     requiredSkills: [], 
     type: '',
     forceCreate: false,
-    status: 'Draft'
+    status: 'Draft',
+    resourceRequests: []
   };
 
   isEditMode = false;
@@ -45,6 +48,7 @@ export class CreateEventComponent implements OnInit {
   selectedSkills: string[] = [];
   otherSkills: string = '';
   suggestedSkills: string[] = [];
+  resourceRequests: ResourceRequest[] = [];
   
   private skillSuggestions: { [key: string]: string[] } = {
     'Environmental': ['Reciklaža', 'Upravljanje otpadom', 'Biologija', 'Ekologija', 'Održivi razvoj', 'Čišćenje', 'Edukacija o klimatskim promjenama'],
@@ -89,6 +93,7 @@ export class CreateEventComponent implements OnInit {
     if (this.eventId) {
       this.eventService.getEventById(this.eventId).subscribe(eventData => {
         this.event = eventData;
+        console.log(eventData);
         this.startTimeDate = new Date(eventData.startTime);
         this.startTimeTime = this.formatTime(eventData.startTime);
         this.endTimeDate = new Date(eventData.endTime);
@@ -157,7 +162,7 @@ export class CreateEventComponent implements OnInit {
       allSkills = [...allSkills, ...manualSkills];
     }
     this.event.requiredSkills = allSkills;
-
+    console.log(this.event);
     if (this.isEditMode && this.eventId) {
       this.modalAction = 'save';
       this.showModalMessage('Da li ste sigurni da želite da ažurirate ovaj događaj?');
@@ -188,7 +193,8 @@ export class CreateEventComponent implements OnInit {
       RequiredSkills: this.event.requiredSkills,
       Type: this.typeMapping[this.event.type],
       ForceCreate: this.event.forceCreate,
-      Status: this.event.status 
+      Status: this.event.status,
+      resourceRequests: this.event.resourceRequests
     };
 
     console.log('Finalni podaci koji se šalju servisu:', eventToSend);
@@ -223,7 +229,8 @@ export class CreateEventComponent implements OnInit {
       RequiredSkills: this.event.requiredSkills,
       Type: this.typeMapping[this.event.type],
       ForceCreate: this.event.forceCreate,
-      Status: this.event.status
+      Status: this.event.status,
+      resourceRequests: this.event.resourceRequests
     };
 
     this.eventService.createEvent(eventToSend).subscribe({
@@ -271,4 +278,84 @@ export class CreateEventComponent implements OnInit {
       width: '600px',
     });
   }
+
+  addResource() {
+  const dialogRef = this.dialog.open(CreateResourceDialogComponent, {
+    width: '450px',
+    disableClose: true,
+  });
+
+  dialogRef.afterClosed().subscribe(result => {
+    if (result) {
+      this.event.resourceRequests.push({
+        eventId: 0,
+        itemName: result.name,
+        quantityNeeded: result.quantity,
+        category: result.category
+      });
+    }
+  });
+  }
+
+  removeResource(index: number) {
+    this.event.resourceRequests.splice(index, 1);
+  }
+
+  getResourceCategoryName(categoryValue: string | number): string {
+     if (typeof categoryValue === 'string') {
+    return categoryValue;
+  }
+    return ResourceCategory[categoryValue];
+  }
+
+getCategoryClass(category: string | number): string {
+  if (typeof category === 'number') {
+    category = ResourceCategory[category];
+  }
+
+  switch (category) {
+    case 'Oprema':
+      return 'category-badge-equipment';
+    case 'Hrana':
+      return 'category-badge-food';
+    case 'Piće':
+      return 'category-badge-drink';
+    case 'Prostor':
+      return 'category-badge-space';
+    case 'Prevoz':
+      return 'category-badge-transport';
+    case 'Materijal':
+      return 'category-badge-material';
+    case 'Ostalo':
+      return 'category-badge-other';
+    default:
+      return 'category-badge-default';
+  }
 }
+
+getCategoryIcon(category: string | number): string {
+  if (typeof category === 'number') {
+    category = ResourceCategory[category];
+  }
+
+  switch (category) {
+    case 'Oprema':
+      return 'chair';
+    case 'Prostor':
+      return 'meeting_room';
+    case 'Prevoz':
+      return 'directions_car';
+    case 'Materijal':
+      return 'build';
+    case 'Hrana':
+      return 'restaurant';
+    case 'Piće':
+      return 'liquor';
+    case 'Ostalo':
+      return 'more_horiz';
+    default:
+      return 'help_outline'; 
+  }
+}
+}
+

--- a/Frontend/KindNet/src/app/create-resource-dialog/create-resource-dialog.component.css
+++ b/Frontend/KindNet/src/app/create-resource-dialog/create-resource-dialog.component.css
@@ -1,0 +1,19 @@
+.resource-form {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.save-button {
+  background-color: #e07a5f !important;
+  color: white !important;
+}
+
+::ng-deep .mat-form-field-appearance-outline .mat-form-field-label {
+  background: #fff; 
+  padding: 0 4px;
+}

--- a/Frontend/KindNet/src/app/create-resource-dialog/create-resource-dialog.component.html
+++ b/Frontend/KindNet/src/app/create-resource-dialog/create-resource-dialog.component.html
@@ -1,0 +1,33 @@
+<h2 mat-dialog-title>Dodaj novi resurs</h2>
+
+<mat-dialog-content>
+  <form [formGroup]="resourceForm" class="resource-form">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Naziv resursa</mat-label>
+      <input matInput formControlName="name" placeholder="Npr. Flašice vode, Stolice...">
+      <mat-error *ngIf="resourceForm.get('name')?.hasError('required')">Naziv je obavezan.</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Kategorija</mat-label>
+      <mat-select formControlName="category">
+        <mat-option *ngFor="let cat of resourceCategories" [value]="cat.value">
+          {{ cat.viewValue }}
+        </mat-option>
+      </mat-select>
+      <mat-error *ngIf="resourceForm.get('category')?.hasError('required')">Kategorija je obavezna.</mat-error>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Potrebna količina</mat-label>
+      <input matInput type="number" formControlName="quantity" placeholder="10">
+      <mat-error *ngIf="resourceForm.get('quantity')?.hasError('required')">Količina je obavezna.</mat-error>
+      <mat-error *ngIf="resourceForm.get('quantity')?.hasError('min')">Količina mora biti bar 1.</mat-error>
+    </mat-form-field>
+  </form>
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="onCancel()">Otkaži</button>
+  <button mat-flat-button color="primary" class="save-button" [disabled]="!resourceForm.valid" (click)="onSave()">Sačuvaj resurs</button>
+</mat-dialog-actions>

--- a/Frontend/KindNet/src/app/create-resource-dialog/create-resource-dialog.component.spec.ts
+++ b/Frontend/KindNet/src/app/create-resource-dialog/create-resource-dialog.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CreateResourceDialogComponent } from './create-resource-dialog.component';
+
+describe('CreateResourceDialogComponent', () => {
+  let component: CreateResourceDialogComponent;
+  let fixture: ComponentFixture<CreateResourceDialogComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [CreateResourceDialogComponent]
+    });
+    fixture = TestBed.createComponent(CreateResourceDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/Frontend/KindNet/src/app/create-resource-dialog/create-resource-dialog.component.ts
+++ b/Frontend/KindNet/src/app/create-resource-dialog/create-resource-dialog.component.ts
@@ -1,0 +1,48 @@
+import { Component } from '@angular/core';
+import { ResourceCategory } from '../models/resource.model';
+import { FormGroup, FormBuilder, Validators } from '@angular/forms';
+import { MatDialogRef } from '@angular/material/dialog';
+
+@Component({
+  selector: 'app-create-resource-dialog',
+  templateUrl: './create-resource-dialog.component.html',
+  styleUrls: ['./create-resource-dialog.component.css']
+})
+export class CreateResourceDialogComponent {
+  resourceForm: FormGroup;
+  resourceCategories: { value: number, viewValue: string }[] = [];
+
+  constructor(
+    private fb: FormBuilder,
+    public dialogRef: MatDialogRef<CreateResourceDialogComponent>
+  ) {
+    this.resourceForm = this.fb.group({
+      name: ['', Validators.required],
+      category: ['', Validators.required],
+      quantity: [1, [Validators.required, Validators.min(1)]]
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadCategories();
+  }
+
+  loadCategories() {
+    this.resourceCategories = Object.keys(ResourceCategory)
+      .filter(key => !isNaN(Number(ResourceCategory[key as any])))
+      .map(key => ({
+        value: Number(ResourceCategory[key as any]),
+        viewValue: key
+      }));
+  }
+
+  onCancel(): void {
+    this.dialogRef.close();
+  }
+
+  onSave(): void {
+    if (this.resourceForm.valid) {
+      this.dialogRef.close(this.resourceForm.value);
+    }
+  }
+}

--- a/Frontend/KindNet/src/app/models/event.model.ts
+++ b/Frontend/KindNet/src/app/models/event.model.ts
@@ -1,3 +1,5 @@
+import { ResourceRequest } from "./resource.model";
+
 export interface CreateEventDto {
   name: string;
   description: string;
@@ -9,6 +11,7 @@ export interface CreateEventDto {
   forceCreate: boolean;
   applicationDeadline: Date;
   requiredSkills: string[];
+  resourceRequests: ResourceRequest[]; 
 }
 
 export interface EventDto {
@@ -23,6 +26,7 @@ export interface EventDto {
   applicationDeadline: Date;
   requiredSkills: string[];
   organizerName: string;
+  resourceRequests: ResourceRequest[]; 
 }
 
 export interface CreateEventResultDto {
@@ -41,6 +45,7 @@ export interface CreateEventPayload {
   ForceCreate: boolean;
   ApplicationDeadline: string;
   RequiredSkills: string[];
+  resourceRequests: ResourceRequest[]; 
 }
 export enum EventStatus {
   Draft = 0,

--- a/Frontend/KindNet/src/app/models/resource.model.ts
+++ b/Frontend/KindNet/src/app/models/resource.model.ts
@@ -1,0 +1,24 @@
+export enum ResourceCategory {
+  Oprema = 0,
+  Prostor = 1,
+  Prevoz = 2,
+  Materijal = 3,
+  Hrana = 4,
+  Piće = 5,
+  Ostalo = 6
+}
+
+export interface ResourceRequest {
+  eventId: number;
+  itemName: string;               
+  quantityNeeded: number;           
+  category: ResourceCategory; 
+}
+
+export interface ResourceFulfillment {
+  id: number;                 
+  resourceRequestId: number;  
+  providerId: number;         
+  providedQuantity: number;   
+  providedAt: Date;           
+}


### PR DESCRIPTION
## Description
This PR introduces support for resource requests during event creation and editing.
Organizers can now specify which resources are required for an event, including:

-Resource name
-Category (Food, Drinks, Transport, Equipment, Material, etc.)
-Quantity

Resource requests can also be managed when editing an event, allowing organizers to add new resources or remove existing ones, but only while the event is in Draft status.
<img width="937" height="542" alt="Screenshot 2025-09-10 180752" src="https://github.com/user-attachments/assets/8f6c155d-a1ff-4a63-a780-bba29220f5b2" />
